### PR TITLE
Multiprocessing

### DIFF
--- a/jano/__init__.py
+++ b/jano/__init__.py
@@ -1,3 +1,4 @@
+import os
 from itertools import chain
 from multiprocessing import Pool
 from typing import List
@@ -31,7 +32,7 @@ def extract_data(url: str) -> dict:
     find = SearchController(artigo.domain)
     data = find.search(artigo.titulo)
     cpus = available_cpu_count()
-    if len(data) > cpus > 1:
+    if len(data) > cpus > 1 and os.environ.get('CORE_MULTIPROCESSING'):
         print("Usando suporte multi-core com {0} núcleos".format(cpus))
         list_parts = split_list(data, wanted_parts=cpus)
         with Pool(processes=cpus) as pool:

--- a/jano/controllers/SearchController.py
+++ b/jano/controllers/SearchController.py
@@ -1,11 +1,11 @@
-import _thread
 import os
-from queue import Queue
-from typing import List
+from multiprocessing import Process, Queue
+from typing import List, Optional
 
 from jano.exceptions import NoAzureKey, JunoException
 from jano.search.bing import BingCrawler
 from jano.search.google import GoogleCrawler
+from jano.util import available_cpu_count
 
 
 class SearchController(object):
@@ -13,24 +13,35 @@ class SearchController(object):
         self.__results = []
         self.ignore = ignore
 
-    def bing_wrapper(self, query: str, q: Queue):
+    def bing_wrapper(self, query: str, q: Optional[Queue]):
         bing = BingCrawler(os.environ.get('MS_BING_KEY'), self.ignore)
         values = bing.search_relatives(query)
-        q.put(values)
+        if q is not None:
+            q.put(values)
+        return values
 
-    def google_wrapper(self, query: str, q: Queue):
+    def google_wrapper(self, query: str, q: Optional[Queue]):
         google = GoogleCrawler(self.ignore)
         values = google.search_relatives(query)
-        q.put(values)
+        if q is not None:
+            q.put(values)
+        return values
 
     def search(self, query: str) -> List:
         try:
             if not os.environ.get('MS_BING_KEY'):
                 raise NoAzureKey("Uma chave do Bing deve estar em MS_BING_KEY")
+            cpus = available_cpu_count()
             q = Queue()
-            _thread.start_new_thread(self.google_wrapper, (query, q))
-            _thread.start_new_thread(self.bing_wrapper, (query, q))
-            result = q.get() + q.get()
+            if cpus > 1:
+                proc = Process(target=self.bing_wrapper, args=(query, q,)), Process(target=self.google_wrapper,
+                                                                                    args=(query, q,))
+                for p in proc:
+                    p.start()
+                result = q.get() + q.get()
+            else:
+                result = self.bing_wrapper(query, None) + self.google_wrapper(query, None)
+                q.empty()
             return result
         except Exception as e:
             raise JunoException(e.__str__())

--- a/jano/controllers/SearchController.py
+++ b/jano/controllers/SearchController.py
@@ -33,7 +33,7 @@ class SearchController(object):
                 raise NoAzureKey("Uma chave do Bing deve estar em MS_BING_KEY")
             cpus = available_cpu_count()
             q = Queue()
-            if cpus > 1:
+            if cpus > 1 and os.environ.get('CORE_MULTIPROCESSING'):
                 proc = Process(target=self.bing_wrapper, args=(query, q,)), Process(target=self.google_wrapper,
                                                                                     args=(query, q,))
                 for p in proc:

--- a/pales/controllers/BuilderController.py
+++ b/pales/controllers/BuilderController.py
@@ -1,5 +1,6 @@
 import numpy
 
+from carmenta import score
 from jano import Config
 from pales.controllers.KerasController import KerasController
 


### PR DESCRIPTION
Habilitado a possibilidade de utilizar vários núcleos nos processamentos de extração, no Jano e Carmenta. Para habilitar esta opção é necessário definir a variável de ambiente `CORE_MULTIPROCESSING`. Este pull-request irá requerer que todo o código que utilize este núcleo seja executado dentro de um `__main__` devido a limitações do módulo [multiprocessing](https://docs.python.org/3/library/multiprocessing.html)