### PR TITLE
Uso de cache em Jano

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Cache
+jano/cache/*
+!jano/cache/.gitkeep
+
 # Testes
 hello.py
 

--- a/jano/__init__.py
+++ b/jano/__init__.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 from itertools import chain
 from multiprocessing import Pool
@@ -5,6 +6,7 @@ from typing import List
 
 from jano.config import Config
 from jano.controllers.ArticleExtractor import ArticleExtractor
+from jano.controllers.CacheController import CacheController
 from jano.controllers.SearchController import SearchController
 from jano.models import SearchObject
 from jano.util import split_list, available_cpu_count
@@ -24,6 +26,10 @@ def extractor(data: List):
 
 
 def extract_data(url: str) -> dict:
+    cache = CacheController.getCache(url)
+    if cache:
+        return cache
+
     dados = {
         "original": None,
         "meta": []
@@ -43,4 +49,5 @@ def extract_data(url: str) -> dict:
         results = extractor(data)
     dados["meta"] = results
     dados['original'] = artigo
+    CacheController.createCache(dados)
     return dados

--- a/jano/controllers/CacheController.py
+++ b/jano/controllers/CacheController.py
@@ -1,0 +1,37 @@
+import hashlib
+import os
+import pickle
+from typing import Union
+
+import pendulum
+
+from carmenta.exceptions import InvalidJunoObject
+from jano import Config
+from jano.util import jano_index
+
+
+class CacheController(object):
+    @staticmethod
+    def getCache(url: str) -> Union[dict, bool]:
+        hashed = hashlib.sha224(str(url).encode('utf-8')).hexdigest()
+        cache = os.path.normpath(jano_index() + os.path.normcase("/cache/{0}.jcache".format(hashed)))
+        if os.path.isfile(cache):
+            time = pendulum.from_timestamp(os.path.getmtime(cache))
+            now = pendulum.now(Config.values()['timezone'])
+            if now.diff(time).in_days() >= 2:
+                os.remove(cache)
+                return False
+            return pickle.load(open(cache, "rb"))
+        else:
+            return False
+
+    @staticmethod
+    def createCache(dados: dict) -> bool:
+        if 'original' not in dados and 'meta' not in dados:
+            raise InvalidJunoObject("Dicionário deve ser um dicionário extraído de juno.extract_data")
+        hashed = hashlib.sha224(str(dados['original'].url).encode('utf-8')).hexdigest()
+        cache = os.path.normpath(jano_index() + os.path.normcase("/cache/{0}.jcache".format(hashed)))
+        pickle_out = open(cache, "wb")
+        pickle.dump(dados, pickle_out)
+        pickle_out.close()
+        return True

--- a/jano/util/__init__.py
+++ b/jano/util/__init__.py
@@ -8,6 +8,10 @@ from ftfy import fix_encoding
 from jano.config import Config
 
 
+def jano_index():
+    return os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")
+
+
 def normalizeword(palavra: str) -> str:
     """
     Normaliza uma palavra individualmente (remove acento e caracteres especiais)


### PR DESCRIPTION
Jano utilizará cache de extrações para acelerar o processo de análise, caches tem uma validade de 48 horas.